### PR TITLE
Make meioc more easily usable as a library

### DIFF
--- a/meioc.py
+++ b/meioc.py
@@ -20,6 +20,9 @@ from email import policy
 from bs4 import BeautifulSoup
 from email.parser import BytesParser
 
+from io import BytesIO
+import pytest
+
 warnings.simplefilter(action="ignore", category=FutureWarning)
 tldcache = tldextract.TLDExtract(cache_file="./.tld_set")
 encodings.aliases.aliases["cp_850"] = "cp850"
@@ -261,8 +264,17 @@ def email_analysis(byte_stream, exclude_private_ip, check_spf, filename):
 
             resultmeioc["spf"] = testspf
 
-        return resultmeioc
+    return resultmeioc
 
+def test_degenerate_1():
+    empty = BytesIO(b'')
+    r = email_analysis(empty, False, False, '/foo/bar/empty.eml')
+    # it always returns a dictionary of info
+    assert isinstance(r, dict)
+    # it takes the basename of the input filename
+    assert r['filename'] == 'empty.eml'
+    # it starts with everything being None
+    assert all(r[k] is None for k in r.keys() if k != 'filename')
 
 def main():
     version = "1.2"

--- a/meioc.py
+++ b/meioc.py
@@ -27,6 +27,7 @@ warnings.simplefilter(action="ignore", category=FutureWarning)
 tldcache = tldextract.TLDExtract(cache_file="./.tld_set")
 encodings.aliases.aliases["cp_850"] = "cp850"
 
+__all__ = ['email_analysis', 'main']
 
 def email_analysis(byte_stream, exclude_private_ip, check_spf, filename):
     urlList = []

--- a/meioc.py
+++ b/meioc.py
@@ -189,13 +189,13 @@ def email_analysis(byte_stream, exclude_private_ip, check_spf, filename):
                         hopList.append(hop[0])
 
         if hopList:
-            resultmeioc["relay_full"] = dict(zip(range(len(hopList)), hopList))
+            resultmeioc["relay_full"] = dict(enumerate(hopList))
 
         if hopListIP:
             if exclude_private_ip:
-                resultmeioc["relay_ip"] = dict(zip(range(len(hopListIPnoPrivate)), hopListIPnoPrivate))
+                resultmeioc["relay_ip"] = dict(enumerate(hopListIPnoPrivate))
             else:
-                resultmeioc["relay_ip"] = dict(zip(range(len(hopListIP)), hopListIP))
+                resultmeioc["relay_ip"] = dict(enumerate(hopListIP))
 
         #
         # Body analysis

--- a/meioc.py
+++ b/meioc.py
@@ -101,7 +101,7 @@ def email_analysis(byte_stream, exclude_private_ip, check_spf, filename):
 
             if mail_to:
                 # Remove possible duplicates and create a numbered dictionary
-                mail_to = dict(zip(range(len(list(set(mail_to)))), list(set(mail_to))))
+                mail_to = dict(enumerate(sorted(set(mail_to))))
                 resultmeioc["to"] = mail_to
 
         if msg["Bcc"]:
@@ -121,7 +121,7 @@ def email_analysis(byte_stream, exclude_private_ip, check_spf, filename):
 
             if mail_ccList:
                 # Remove possible duplicates and create a numbered dictionary
-                mail_ccList = dict(zip(range(len(list(set(mail_ccList)))), list(set(mail_ccList))))
+                mail_ccList = dict(enumerate(sorted(set(mail_ccList))))
                 resultmeioc["cc"] = mail_ccList
 
         if msg["Envelope-to"]:
@@ -132,7 +132,7 @@ def email_analysis(byte_stream, exclude_private_ip, check_spf, filename):
 
             if mail_envelopeto:
                 # Remove possible duplicates and create a numbered dictionary
-                mail_envelopeto = dict(zip(range(len(list(set(mail_envelopeto)))), list(set(mail_envelopeto))))
+                mail_envelopeto = dict(enumerate(sorted(set(mail_envelopeto))))
                 resultmeioc["envelope-to"] = mail_envelopeto
 
         if msg["Delivered-To"]:

--- a/meioc.py
+++ b/meioc.py
@@ -266,6 +266,7 @@ def email_analysis(byte_stream, exclude_private_ip, check_spf, filename):
 
     return resultmeioc
 
+
 def test_degenerate_1():
     empty = BytesIO(b'')
     r = email_analysis(empty, False, False, '/foo/bar/empty.eml')
@@ -275,6 +276,17 @@ def test_degenerate_1():
     assert r['filename'] == 'empty.eml'
     # it starts with everything being None
     assert all(r[k] is None for k in r.keys() if k != 'filename')
+
+
+def test_minimum_valid_email():
+    x = BytesIO(b'''\
+From: a@example.com\r
+\r
+Body\r
+''')
+    r = email_analysis(x, False, False, 'minimumvalid.eml')
+    assert r['from'] == 'a@example.com'
+
 
 def main():
     version = "1.2"

--- a/meioc.py
+++ b/meioc.py
@@ -74,21 +74,21 @@ def email_analysis(byte_stream, exclude_private_ip, check_spf, filename):
             #
             # Sender Name: Mario Rossi <rossi.mario@example.com>
             # Sender Mail: spoof@example.com
-            mail_from = re.findall("[A-Za-z0-9.!#$%&'*+\/=?^_`{|}~\-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}", msg["From"],
+            mail_from = re.findall(r"[A-Za-z0-9.!#$%&'*+\/=?^_`{|}~\-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}", msg["From"],
                                    re.IGNORECASE)
 
             if mail_from:
                 resultmeioc["from"] = mail_from[-1]
 
         if msg["Sender"]:
-            mail_sender = re.findall("[A-Za-z0-9.!#$%&'*+\/=?^_`{|}~\-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}", msg["Sender"],
+            mail_sender = re.findall(r"[A-Za-z0-9.!#$%&'*+\/=?^_`{|}~\-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}", msg["Sender"],
                                      re.IGNORECASE)
 
             if mail_sender:
                 resultmeioc["sender"] = mail_sender[-1]
 
         if msg["X-Sender"]:
-            mail_xsender = re.findall("[A-Za-z0-9.!#$%&'*+\/=?^_`{|}~\-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}",
+            mail_xsender = re.findall(r"[A-Za-z0-9.!#$%&'*+\/=?^_`{|}~\-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}",
                                       msg["X-Sender"],
                                       re.IGNORECASE)
 
@@ -96,7 +96,7 @@ def email_analysis(byte_stream, exclude_private_ip, check_spf, filename):
                 resultmeioc["x-sender"] = mail_xsender[-1]
 
         if msg["To"]:
-            mail_to = re.findall("[A-Za-z0-9.!#$%&'*+\/=?^_`{|}~\-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}", msg["To"],
+            mail_to = re.findall(r"[A-Za-z0-9.!#$%&'*+\/=?^_`{|}~\-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}", msg["To"],
                                  re.IGNORECASE)
 
             if mail_to:
@@ -114,7 +114,7 @@ def email_analysis(byte_stream, exclude_private_ip, check_spf, filename):
             # Cc Mail: spoof@example.com
             mail_ccList = []
             for mail in msg["Cc"].split(","):
-                mail_cc = re.findall("[A-Za-z0-9.!#$%&'*+\/=?^_`{|}~\-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}", mail,
+                mail_cc = re.findall(r"[A-Za-z0-9.!#$%&'*+\/=?^_`{|}~\-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}", mail,
                                      re.IGNORECASE)
                 if mail_cc:
                     mail_ccList.append(mail_cc[-1])
@@ -126,7 +126,7 @@ def email_analysis(byte_stream, exclude_private_ip, check_spf, filename):
 
         if msg["Envelope-to"]:
 
-            mail_envelopeto = re.findall("[A-Za-z0-9.!#$%&'*+\/=?^_`{|}~\-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}",
+            mail_envelopeto = re.findall(r"[A-Za-z0-9.!#$%&'*+\/=?^_`{|}~\-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}",
                                          msg["Envelope-to"],
                                          re.IGNORECASE)
 
@@ -139,7 +139,7 @@ def email_analysis(byte_stream, exclude_private_ip, check_spf, filename):
             resultmeioc["delivered-to"] = msg["Delivered-To"]
 
         if msg["Return-Path"]:
-            mail_returnpath = re.findall("[A-Za-z0-9.!#$%&'*+\/=?^_`{|}~\-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}",
+            mail_returnpath = re.findall(r"[A-Za-z0-9.!#$%&'*+\/=?^_`{|}~\-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}",
                                          msg["Return-Path"],
                                          re.IGNORECASE)
 
@@ -159,7 +159,7 @@ def email_analysis(byte_stream, exclude_private_ip, check_spf, filename):
         if received:
             received.reverse()
             for line in received:
-                hops = re.findall("from\s+(.*?)\s+by(.*?)(?:(?:with|via)(.*?)(?:id|$)|id|$)", line,
+                hops = re.findall(r"from\s+(.*?)\s+by(.*?)(?:(?:with|via)(.*?)(?:id|$)|id|$)", line,
                                   re.DOTALL | re.X)
                 for hop in hops:
 
@@ -204,7 +204,7 @@ def email_analysis(byte_stream, exclude_private_ip, check_spf, filename):
             if part.get_content_type() == "text/plain":
                 # https://gist.github.com/dperini/729294
                 urlList.extend(re.findall(
-                    "(?:(?:(?:https?|ftp):)?\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z0-9\u00a1-\uffff][a-z0-9\u00a1-\uffff_-]{0,62})?[a-z0-9\u00a1-\uffff]\.)+(?:[a-z\u00a1-\uffff]{2,}\.?))(?::\d{2,5})?(?:[/?#]\S*)?",
+                    r"(?:(?:(?:https?|ftp):)?\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z0-9\u00a1-\uffff][a-z0-9\u00a1-\uffff_-]{0,62})?[a-z0-9\u00a1-\uffff]\.)+(?:[a-z\u00a1-\uffff]{2,}\.?))(?::\d{2,5})?(?:[/?#]\S*)?",
                     part.get_content(), re.UNICODE | re.IGNORECASE | re.MULTILINE))
 
             if part.get_content_type() == "text/html":

--- a/meioc.py
+++ b/meioc.py
@@ -304,11 +304,12 @@ From: a@example.com\r
 Body\r
 '''.format(header_field=header_field).encode('ascii'))
     r = email_analysis(x, False, False, 'multiple_address.eml')
-    # duplicates are removed. at this writing, order is not guaranteed.
-    assert sorted(list(r[analysis_key].keys())) == [0, 1, 2]
-    assert sorted(list(r[analysis_key].values())) == ['b@example.com',
-                                                      'c@example.com',
-                                                      'd@example.com']
+    # duplicates are removed. values are sorted.
+    assert list(r[analysis_key].keys()) == [0, 1, 2]
+    assert list(r[analysis_key].values()) == ['b@example.com',
+                                              'c@example.com',
+                                              'd@example.com']
+
 
 def main():
     version = "1.2"

--- a/meioc.py
+++ b/meioc.py
@@ -287,6 +287,28 @@ Body\r
     r = email_analysis(x, False, False, 'minimumvalid.eml')
     assert r['from'] == 'a@example.com'
 
+# http://pytest.org/en/latest/parametrize.html#pytest-mark-parametrize-parametrizing-test-functions
+@pytest.mark.parametrize('header_field,analysis_key',
+                         [('To', 'to'),
+                          ('Envelope-to', 'envelope-to'),
+                          ('Cc', 'cc')])
+def test_multiple_address_values(header_field, analysis_key):
+    x = BytesIO('''\
+From: a@example.com\r
+{header_field}: b@example.com,\r
+  c@example.com,\r
+  c@example.com,\r
+  c@example.com,\r
+  d@example.com,\r
+\r
+Body\r
+'''.format(header_field=header_field).encode('ascii'))
+    r = email_analysis(x, False, False, 'multiple_address.eml')
+    # duplicates are removed. at this writing, order is not guaranteed.
+    assert sorted(list(r[analysis_key].keys())) == [0, 1, 2]
+    assert sorted(list(r[analysis_key].values())) == ['b@example.com',
+                                                      'c@example.com',
+                                                      'd@example.com']
 
 def main():
     version = "1.2"

--- a/meioc.py
+++ b/meioc.py
@@ -261,7 +261,7 @@ def email_analysis(byte_stream, exclude_private_ip, check_spf, filename):
 
             resultmeioc["spf"] = testspf
 
-        print(json.dumps(resultmeioc, indent=4))
+        return resultmeioc
 
 
 def main():
@@ -278,7 +278,8 @@ def main():
 
     if arguments.filename:
         with open(arguments.filename, 'rb') as fp:
-            email_analysis(fp, arguments.excprip, arguments.spf, arguments.filename)
+            resultmeioc = email_analysis(fp, arguments.excprip, arguments.spf, arguments.filename)
+            print(json.dumps(resultmeioc, indent=4))
 
 
 if __name__ == "__main__":

--- a/meioc.py
+++ b/meioc.py
@@ -25,7 +25,7 @@ tldcache = tldextract.TLDExtract(cache_file="./.tld_set")
 encodings.aliases.aliases["cp_850"] = "cp850"
 
 
-def email_analysis(filename, exclude_private_ip, check_spf):
+def email_analysis(byte_stream, exclude_private_ip, check_spf, filename):
     urlList = []
     hopList = []
     hopListIP = []
@@ -55,8 +55,7 @@ def email_analysis(filename, exclude_private_ip, check_spf):
         "attachments": None
     }
 
-    with open(filename, "rb") as fp:
-        msg = BytesParser(policy=policy.default).parse(fp)
+    msg = BytesParser(policy=policy.default).parse(byte_stream)
 
     if msg:
 
@@ -278,7 +277,8 @@ def main():
     arguments = parser.parse_args()
 
     if arguments.filename:
-        email_analysis(arguments.filename, arguments.excprip, arguments.spf)
+        with open(arguments.filename, 'rb') as fp:
+            email_analysis(fp, arguments.excprip, arguments.spf, arguments.filename)
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ tldextract==2.2.2
 py3dns
 pyspf
 beautifulsoup4
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-emaildata==0.3.4
-tldextract==2.2.0
+tldextract==2.2.2
 py3dns
 pyspf
-bs4
+beautifulsoup4

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,42 @@
+from setuptools import setup
+
+setup(
+    name='meioc',
+    version='0.1.0',
+    description='Extract indicators of compromise from an eml file',
+    author='Andrea Draghetti',
+    author_email='drego85@draghetti.it',
+    url='https://github.com/drego85/meioc',
+    py_modules=['meioc'],
+    entry_points={
+        'console_scripts': ['meioc = meioc:main']},
+    long_description='''\
+Meioc (Mail Extractor IoC) extracts indicators of compromise from eMail.
+
+Meioc allows you to extract the following information from an e-mail, in JSON format:
+
+ * From
+ * Sender
+ * X-Sender
+ * To
+ * Cc
+ * Bcc
+ * Envelope-to
+ * Delivered-to
+ * Return-Path
+ * Subject
+ * Date
+ * X-Originating-IP
+ * Relay Full
+ * Relay IP (Only the IPs involved with the possibility of excluding private IPs)
+ * Urls
+ * Domains
+ * Attachments with hash
+ * Check SPF record
+
+''',
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+        'Programming Language :: Python :: 3',
+    ])


### PR DESCRIPTION
meioc works as a script that takes a file and produces results on stdout. This set of changes preserves that functionality, and adds the ability to import meioc, call `run_analysis` as a function, and receive its results as the return value of the function, rather than as printed output.

The ability to call `run_analysis` as a function also makes it easier to write automated tests for it, and some of those are added here, using pytest.

Also, I've replaced some `dict(zip(range(len(x)), x))` with `dict(enumerate(x))` because it seems simpler; the tests confirm that the resultant code works the same.