### PR TITLE
Fixing URL parsing if a <base> tag is present

### DIFF
--- a/meioc.py
+++ b/meioc.py
@@ -210,8 +210,18 @@ def email_analysis(filename, exclude_private_ip, check_spf):
                 try:
                     soup = BeautifulSoup(part.get_content(), "html.parser")
                     tags = soup.find_all("a", href=True)
+
+                    # Handling the cases when a <base> tag is present.
+                    # If this is the case, we must prefix all the URLs by the value of <base>.
+                    tag_base = soup.find_all("base")
+                    if tag_base:
+                        # In browsers, it is the first <base> tag that is applied.
+                        base = tag_base[0].get("href")
+                    else:
+                        base = ''
+
                     for url in tags:
-                        urlList.append(url.get("href"))
+                        urlList.append(base+url.get("href"))
                 except:
                     pass
 


### PR DESCRIPTION
This pull request fixes the parsing of an URL if a `<base>` HTML tag is present in a HTML message: https://www.w3schools.com/tags/tag_base.asp

In the current version, if there is a `<base href="bit.ly/">` somewhere, and a `<a href="a254f">click here</a>` after, the URL reported by meioc will be `a254f`.
This PR fixes this behavior and reports the URL as `bit.ly/a254f`.

PS: I had issues with the line 24:
`tldcache = tldextract.TLDExtract(cache_file="./.tld_set")`
I had to remove the `cache_file=` during my tests, this is probably due to a new version of tldextract.